### PR TITLE
Provide move information consistent with the request geometry

### DIFF
--- a/include/tinytsumego2/state.h
+++ b/include/tinytsumego2/state.h
@@ -5,6 +5,9 @@
 #include "tinytsumego2/stones.h"
 #include "tinytsumego2/stones16.h"
 
+// Define if external liberty normalization is needed at the make_move() level
+// #define NORMALIZE_EXTERNAL_LIBERTIES
+
 // Game state
 typedef struct state
 {

--- a/src/dual_reader.c
+++ b/src/dual_reader.c
@@ -244,6 +244,10 @@ state strip_aesthetics(const dual_graph_reader *dgr, const state *s) {
   ss.ko = s->ko;
   ss.passes = s->passes;
   ss.button = s->button;
+  stones_t swaps = ss.external ^ s->external;
+  ss.immortal ^= swaps;
+  ss.external ^= swaps;
+  ss.logical_area ^= swaps;
 
   return ss;
 }

--- a/src/state.c
+++ b/src/state.c
@@ -297,12 +297,14 @@ move_result make_move(state *s, stones_t move) {
   }
 
   if (move & s->external) {
-    // Normalize move placement inside the group of external liberties.
-    if (s->wide) {
-      move = 1ULL << ctz(flood_16(move, s->external));
-    } else {
-      move = 1ULL << ctz(flood(move, s->external));
-    }
+    #ifdef NORMALIZE_EXTERNAL_LIBERTIES
+      // Normalize move placement inside the group of external liberties.
+      if (s->wide) {
+        move = 1ULL << ctz(flood_16(move, s->external));
+      } else {
+        move = 1ULL << ctz(flood(move, s->external));
+      }
+    #endif
     s->immortal |= move;
     s->external ^= move;
     result = FILL_EXTERNAL;

--- a/test/test_dual_reader.c
+++ b/test/test_dual_reader.c
@@ -17,6 +17,19 @@ state bulky_five() {
   return s;
 }
 
+state rectangle_six() {
+  state s = {0};
+  s.visual_area = rectangle(4, 5);
+  s.external = rectangle(2, 1) << (3 * V_SHIFT);
+  s.logical_area = rectangle(3, 2) | s.external;
+  s.opponent = rectangle(4, 3) ^ rectangle(3, 2);
+  s.target = s.opponent;
+  s.player = rectangle(4, 2) << (3 * V_SHIFT);
+  s.immortal = s.player ^ s.external;
+  s.ko_threats = 0;
+  return s;
+}
+
 void test_bulky_five() {
   const state root = bulky_five();
   print_state(&root);
@@ -72,7 +85,117 @@ void test_bulky_five() {
   free(buffer);
 }
 
+void test_external_liberties() {
+  const state root = rectangle_six();
+  print_state(&root);
+  dual_graph dg = create_dual_graph(&root);
+  while(iterate_dual_graph(&dg, false));
+  while(area_iterate_dual_graph(&dg, true));
+
+  char *buffer = malloc(MEM_FILE_SIZE);
+  FILE *stream = fmemopen(buffer, MEM_FILE_SIZE, "wb");
+  write_dual_graph(&dg, stream);
+  fclose(stream);
+  free_dual_graph(&dg);
+
+  dual_graph_reader dgr = {0};
+  dgr.fd = -1;
+  dgr.buffer = buffer;
+  unbuffer_dual_graph_reader(&dgr);
+
+  for (size_t i = 0; i < dgr.value_map_size; ++i) {
+    dual_value v = dgr.value_map[i];
+    printf("#%zu: (%f, %f), (%f, %f)\n", i, v.plain.low, v.plain.high, v.forcing.low, v.forcing.high);
+  }
+
+  dual_value v = get_dual_graph_reader_value(&dgr, &root);
+
+  printf("(%f, %f), (%f, %f)\n", v.plain.low, v.plain.high, v.forcing.low, v.forcing.high);
+
+  assert(v.plain.low == -4 + BUTTON_BONUS);
+  assert(v.plain.high == -4 + BUTTON_BONUS);
+  assert(v.forcing.low == -4 + BUTTON_BONUS);
+  assert(v.forcing.high == -1.8125);
+
+  int num_infos = 0;
+  move_info *mis = dual_graph_reader_move_infos(&dgr, &root, &num_infos);
+  bool left_found = false;
+  bool right_found = false;
+  for (int i = 0; i < num_infos; ++i) {
+    assert(mis[i].low_gain <= 0);
+    assert(mis[i].high_gain <= 0);
+    if (mis[i].coords.x == 0 && mis[i].coords.y == 3) {
+      left_found = true;
+    }
+    if (mis[i].coords.x == 1 && mis[i].coords.y == 3) {
+      right_found = true;
+    }
+  }
+  assert(left_found);
+  assert(right_found);
+  free(mis);
+
+  state terminal = dual_graph_reader_low_terminal(&dgr, &root, FORCING);
+  print_state(&terminal);
+  assert(terminal.white_to_play);
+  assert(terminal.player);
+
+  terminal = dual_graph_reader_high_terminal(&dgr, &root, FORCING);
+  print_state(&terminal);
+  assert(terminal.white_to_play);
+  assert(terminal.player);
+
+  state s = root;
+  make_move(&s, single(0, 3));
+  make_move(&s, pass());
+  print_state(&s);
+
+  mis = dual_graph_reader_move_infos(&dgr, &s, &num_infos);
+  left_found = false;
+  right_found = false;
+  for (int i = 0; i < num_infos; ++i) {
+    assert(mis[i].low_gain <= 0);
+    assert(mis[i].high_gain <= 0);
+    if (mis[i].coords.x == 0 && mis[i].coords.y == 3) {
+      left_found = true;
+    }
+    if (mis[i].coords.x == 1 && mis[i].coords.y == 3) {
+      right_found = true;
+    }
+  }
+  assert(!left_found);
+  assert(right_found);
+
+  s = root;
+  make_move(&s, single(1, 3));
+  make_move(&s, pass());
+  print_state(&s);
+
+  mis = dual_graph_reader_move_infos(&dgr, &s, &num_infos);
+  left_found = false;
+  right_found = false;
+  for (int i = 0; i < num_infos; ++i) {
+    assert(mis[i].low_gain <= 0);
+    assert(mis[i].high_gain <= 0);
+    if (mis[i].coords.x == 0 && mis[i].coords.y == 3) {
+      left_found = true;
+    }
+    if (mis[i].coords.x == 1 && mis[i].coords.y == 3) {
+      right_found = true;
+    }
+  }
+  #ifndef NORMALIZE_EXTERNAL_LIBERTIES
+    assert(left_found);
+    assert(!right_found);
+  #endif
+
+  unload_dual_graph_reader(&dgr);
+
+  free(buffer);
+}
+
 int main() {
   test_bulky_five();
+  test_external_liberties();
   return 0;
 }

--- a/test/test_state.c
+++ b/test/test_state.c
@@ -308,7 +308,11 @@ void test_external_liberties() {
 
   r = make_move(&alt, single(1, 1));
   assert(r == FILL_EXTERNAL);
-  assert(equals(&s, &alt));  // Make sure target liberties are filled in standard order
+  #ifdef NORMALIZE_EXTERNAL_LIBERTIES
+    assert(equals(&s, &alt));  // Make sure target liberties are filled in standard order
+  #else
+    assert(!equals(&s, &alt));  // Make sure we don't care right now
+  #endif
 
   r = make_move(&s, pass());
   print_state(&s);
@@ -582,7 +586,11 @@ void test_bent_four_keyspace_coverage() {
   }
 
   printf("%d states expanded\n", num_states);
-  assert(num_states == 55);
+  #ifdef NORMALIZE_EXTERNAL_LIBERTIES
+    assert(num_states == 55);
+  #else
+    assert(num_states == 76);
+  #endif
 
   for (int i = 0; i < num_states; ++i) {
     size_t my_key = to_key(&root, states + i);
@@ -594,7 +602,9 @@ void test_bent_four_keyspace_coverage() {
         print_state(states + j);
       }
       assert(compare(states + i, states + j) != 0);
-      assert(my_key != your_key);
+      #ifdef NORMALIZE_EXTERNAL_LIBERTIES
+        assert(my_key != your_key);
+      #endif
     }
   }
 


### PR DESCRIPTION
Turn external liberty normalization off by default.

ref #50