### PR TITLE
Use a small cage for the bulk of dual_reader values

### DIFF
--- a/dual_solver.c
+++ b/dual_solver.c
@@ -59,16 +59,18 @@ int main(int argc, char *argv[]) {
   } else {
     dual_graph dg = solve(get_tsumego(argv[1]), true);
     if (arg_count >= 3) {
-      size_t value_map_size = 0;
-      dual_table_value *value_map = create_value_map(&dg, &value_map_size);
-      printf("%zu unique value quads in the graph\n", value_map_size);
+      size_t num_unique = 0;
+      frozen_hash_table fht = prepare_frozen_hash(&dg, &num_unique);
+      printf("%zu unique value quads in the graph\n", num_unique);
 
       char *filename = argv[2];
       printf("Saving result to %s\n", filename);
       FILE *f = fopen(filename, "wb");
-      write_dual_graph(&dg, value_map, value_map_size, f);
+      write_dual_graph(&dg, &fht, f);
       fclose(f);
-      free(value_map);
+      free(fht.bulk_map);
+      free(fht.tail_keys);
+      free(fht.tail_values);
     }
     free_dual_graph(&dg);
   }

--- a/generate_collections.c
+++ b/generate_collections.c
@@ -72,16 +72,18 @@ int main(int argc, char *argv[]) {
     }
     if (path) {
       size_t value_map_size = 0;
-      dual_table_value *value_map = create_value_map(&dg, &value_map_size);
+      frozen_hash_table fht = prepare_frozen_hash(&dg, &value_map_size);
       printf("%zu unique value quads in the graph\n", value_map_size);
 
       char *filename = malloc((strlen(path) + strlen(collections[i].slug) + strlen(".bin") + 1) * sizeof(char));
       sprintf(filename, "%s%s.bin", path, collections[i].slug);
       printf("Storing solution to %s\n", filename);
       FILE *f = fopen(filename, "wb");
-      write_dual_graph(&dg, value_map, value_map_size, f);
+      write_dual_graph(&dg, &fht, f);
       fclose(f);
-      free(value_map);
+      free(fht.bulk_map);
+      free(fht.tail_keys);
+      free(fht.tail_values);
       free(filename);
       free_dual_graph(&dg);
       free(collections[i].tsumegos);

--- a/include/tinytsumego2/dual_reader.h
+++ b/include/tinytsumego2/dual_reader.h
@@ -8,6 +8,9 @@
 
 // Read-only version of dual_solver memory mapped directly from the filesystem
 
+// Sentinel value for tail lookup
+#define VALUE_ID_SENTINEL (USHRT_MAX)
+
 typedef struct dual_value {
   value plain;
   value forcing;
@@ -18,14 +21,29 @@ typedef struct dual_table_value {
   table_value forcing;
 } dual_table_value;
 
+// A build-once associative data structure.
+// Optimized for large numbers of integer keys associated with a small number of arbitrary values.
+typedef struct frozen_hash_table {
+  // Mapping from `value_id_t` to `dual_table_value`
+  size_t bulk_map_size;
+  dual_table_value *bulk_map;
+
+  // Entries in `this.bulk_map` or `VALUE_ID_SENTINEL` to propagate lookup to tail
+  value_id_t *bulk_ids;
+
+  // Overflow table of values not found in the bulk section
+  size_t tail_size;
+  dual_table_value *tail_values;
+
+  // `bsearch` indexer to `this.tail_values`
+  size_t *tail_keys;
+} frozen_hash_table;
+
+
 typedef struct dual_graph_reader {
   // Valid moves according to the root state
   int num_moves;
   stones_t *moves;  // NOTE: (m)allocated in RAM
-
-  // List of unique value ranges in the graph
-  size_t value_map_size;
-  dual_value *value_map;  // NOTE: (m)allocated in RAM
 
   // Pre-computed key generator
   keyspace_type type;
@@ -35,8 +53,8 @@ typedef struct dual_graph_reader {
     symmetric_keyspace symmetric;
   } keyspace;  // NOTE: Only partially (m)allocated, do not free()
 
-  // Identifiers of node values inside of self.value_map
-  dual_value_id_t *value_ids;  // NOTE: Not (m)allocated, do not free()
+  // Compressed associator between keys and dual_values
+  frozen_hash_table value_table;  // NOTE: Only partially (m)allocated, do not free()
 
   // For resource acquisition and release
   struct stat sb;
@@ -62,7 +80,7 @@ typedef struct move_info {
 } move_info;
 
 // Write a solved dual_graph instance to a stream in a format expected by the reader
-size_t write_dual_graph(const dual_graph *restrict dg, const dual_table_value *restrict value_map, size_t value_map_size, FILE *restrict stream);
+size_t write_dual_graph(const dual_graph *restrict dg, const frozen_hash_table *restrict fht, FILE *restrict stream);
 
 // Unroll `dgr->buffer` into struct fields
 void unbuffer_dual_graph_reader(dual_graph_reader *dgr);
@@ -94,5 +112,8 @@ state dual_graph_reader_high_terminal(dual_graph_reader *dgr, const state *origi
 // Compare two dual_table_values. Compatible with qsort
 int compare_dual_table_values(const void *a_, const void *b_);
 
-// Prepare value map for `write_dual_graph()`
-dual_table_value* create_value_map(dual_graph *dg, size_t *value_map_size);
+// Prepare value map for `write_dual_graph()` without allocating bulk_ids
+frozen_hash_table prepare_frozen_hash(const dual_graph *dg, size_t *num_unique);
+
+// Map a key to its original dual-value
+dual_table_value get_frozen_hash_value(const frozen_hash_table *fht, size_t key);

--- a/include/tinytsumego2/dual_solver.h
+++ b/include/tinytsumego2/dual_solver.h
@@ -10,7 +10,8 @@
 
 typedef enum {
   COMPRESSED_KEYSPACE,
-  SYMMETRIC_KEYSPACE
+  SYMMETRIC_KEYSPACE,
+  MOCK_KEYSPACE
 } keyspace_type;
 
 // An implicit game graph. All enumerable game states are evaluated even if they're not reachable from the root.
@@ -57,7 +58,7 @@ void print_dual_graph(dual_graph *dg);
 dual_graph create_dual_graph(const state *root, keyspace_type type);
 
 // Work-around for having to re-define `struct dual_graph` in Python ctypes
-dual_graph* allocate_dual_graph(const state *root);
+dual_graph* allocate_dual_graph(const state *root, keyspace_type type);
 
 // Get the value range of a state in the game graph
 value get_dual_graph_value(dual_graph *dg, const state *s, tactics ts);

--- a/include/tinytsumego2/util.h
+++ b/include/tinytsumego2/util.h
@@ -10,8 +10,6 @@
 
 typedef unsigned short int value_id_t;
 
-typedef unsigned int dual_value_id_t;
-
 #define VALUE_MAP_SIZE (1 << (sizeof(value_id_t) * CHAR_BIT))
 
 int ceil_div(int x, int y);

--- a/python/demo.py
+++ b/python/demo.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
 
   lib.print_state(ps)
 
-  pdg = lib.allocate_dual_graph(ps)
+  pdg = lib.allocate_dual_graph(ps, COMPRESSED_KEYSPACE)
   while lib.iterate_dual_graph(pdg, True):
     pass
   root_value = lib.get_dual_graph_value(pdg, ps, FORCING)

--- a/python/lib_types.py
+++ b/python/lib_types.py
@@ -22,6 +22,7 @@ FORCING = 2
 # enum keyspace_type
 COMPRESSED_KEYSPACE = 0
 SYMMETRIC_KEYSPACE = 1
+MOCK_KEYSPACE = 2
 
 # stones.h bitboards
 WIDTH = 9

--- a/src/dual_reader.c
+++ b/src/dual_reader.c
@@ -14,7 +14,7 @@
 #include "tinytsumego2/util.h"
 #include "tinytsumego2/keyspace.h"
 
-#define DUAL_READER_VERSION (3)
+#define DUAL_READER_VERSION (4)
 
 size_t __to_compressed_key(const dual_graph_reader *dgr, const state *s) {
   return to_compressed_key(&(dgr->keyspace.compressed), s);
@@ -24,7 +24,7 @@ size_t __to_symmetric_key(const dual_graph_reader *dgr, const state *s) {
   return to_symmetric_key(&(dgr->keyspace.symmetric), s);
 }
 
-size_t write_dual_graph(const dual_graph *restrict dg, const dual_table_value *restrict value_map, size_t value_map_size, FILE *restrict stream) {
+size_t write_dual_graph(const dual_graph *restrict dg, const frozen_hash_table *restrict fht, FILE *restrict stream) {
   int version = DUAL_READER_VERSION;
   size_t total = fwrite(&version, sizeof(int), 1, stream);
 
@@ -52,19 +52,17 @@ size_t write_dual_graph(const dual_graph *restrict dg, const dual_table_value *r
       dg->plain_values[i],
       dg->forcing_values[i],
     };
-    size_t id = ((dual_table_value *) bsearch(&v, value_map, value_map_size, sizeof(dual_table_value), compare_dual_table_values)) - value_map;
-    dual_value_id_t vid = (dual_value_id_t) id;
-    total += fwrite(&(vid), sizeof(dual_value_id_t), 1, stream);
+    dual_table_value *tv = bsearch(&v, fht->bulk_map, fht->bulk_map_size, sizeof(dual_table_value), compare_dual_table_values);
+    value_id_t vid = tv ? (value_id_t) (tv - fht->bulk_map) : VALUE_ID_SENTINEL;
+    total += fwrite(&(vid), sizeof(value_id_t), 1, stream);
   }
 
-  total += fwrite(&value_map_size, sizeof(size_t), 1, stream);
-  for (size_t i = 0; i < value_map_size; ++i) {
-    dual_value v = (dual_value){
-      {score_q7_to_float(value_map[i].plain.low), score_q7_to_float(value_map[i].plain.high)},
-      {score_q7_to_float(value_map[i].forcing.low), score_q7_to_float(value_map[i].forcing.high)},
-    };
-    total += fwrite(&v, sizeof(dual_value), 1, stream);
-  }
+  total += fwrite(&(fht->bulk_map_size), sizeof(size_t), 1, stream);
+  total += fwrite(fht->bulk_map, sizeof(dual_table_value), fht->bulk_map_size, stream);
+
+  total += fwrite(&(fht->tail_size), sizeof(size_t), 1, stream);
+  total += fwrite(fht->tail_values, sizeof(dual_table_value), fht->tail_size, stream);
+  total += fwrite(fht->tail_keys, sizeof(size_t), fht->tail_size, stream);
 
   return total;
 }
@@ -74,10 +72,7 @@ void unbuffer_dual_graph_reader(dual_graph_reader *dgr) {
 
   int version = ((int *)map)[0];
   map += sizeof(int);
-  // Value mapping differs, but v2 still works with v3
-  if (DUAL_READER_VERSION == 3 && version == 2) {
-    version = 3;
-  }
+
   if (version != DUAL_READER_VERSION) {
     fprintf(stderr, "Unknown dual graph version %d\n", version);
     exit(EXIT_FAILURE);
@@ -118,9 +113,12 @@ void unbuffer_dual_graph_reader(dual_graph_reader *dgr) {
   if (dgr->type == COMPRESSED_KEYSPACE) {
     dgr->keyspace.compressed.keyspace = create_tight_keyspace(&(dgr->keyspace._.root), true);
     dgr->to_key = __to_compressed_key;
-  } else {
+  } else if (dgr->type == SYMMETRIC_KEYSPACE) {
     dgr->keyspace.symmetric.symmetry = compute_symmetry(&(dgr->keyspace._.root));
     dgr->to_key = __to_symmetric_key;
+  } else {
+    // Support testing of mock keyspaces
+    dgr->to_key = NULL;
   }
 
   dgr->num_moves = ((int*) map)[0];
@@ -132,17 +130,25 @@ void unbuffer_dual_graph_reader(dual_graph_reader *dgr) {
   }
   map += dgr->num_moves * sizeof(stones_t);
 
-  dgr->value_ids = (dual_value_id_t *)map;
-  map += sizeof(dual_value_id_t) * dgr->keyspace._.size;
+  dgr->value_table.bulk_ids = (value_id_t *)map;
+  map += sizeof(value_id_t) * dgr->keyspace._.size;
 
-  dgr->value_map_size = ((size_t*) map)[0];
+  dgr->value_table.bulk_map_size = ((size_t*) map)[0];
   map += sizeof(size_t);
 
-  dgr->value_map = malloc(dgr->value_map_size * sizeof(dual_value));
-  for (size_t i = 0; i < dgr->value_map_size; ++i) {
-    dgr->value_map[i] = ((dual_value *)map)[i];
+  dgr->value_table.bulk_map = malloc(dgr->value_table.bulk_map_size * sizeof(dual_table_value));
+  for (size_t i = 0; i < dgr->value_table.bulk_map_size; ++i) {
+    dgr->value_table.bulk_map[i] = ((dual_table_value *)map)[i];
   }
-  map += sizeof(dual_value) * dgr->value_map_size;
+  map += sizeof(dual_table_value) * dgr->value_table.bulk_map_size;
+
+  dgr->value_table.tail_size = ((size_t*) map)[0];
+  map += sizeof(size_t);
+
+  dgr->value_table.tail_values = (dual_table_value*)map;
+  map += dgr->value_table.tail_size * sizeof(dual_table_value);
+  dgr->value_table.tail_keys = (size_t*)map;
+  map += dgr->value_table.tail_size * sizeof(size_t);
 }
 
 dual_graph_reader load_dual_graph_reader(const char *filename) {
@@ -159,17 +165,19 @@ dual_graph_reader load_dual_graph_reader(const char *filename) {
 void unload_dual_graph_reader(dual_graph_reader *dgr) {
   if (dgr->type == COMPRESSED_KEYSPACE) {
     free_tight_keyspace(&(dgr->keyspace.compressed.keyspace));
-  } else {
+  } else if (dgr->type == SYMMETRIC_KEYSPACE){
     free_symmetry(&(dgr->keyspace.symmetric.symmetry));
+  } else {
+    printf("Unloading mock keyspace\n");
   }
 
   free(dgr->moves);
   dgr->num_moves = 0;
   dgr->moves = NULL;
 
-  free(dgr->value_map);
-  dgr->value_map_size = 0;
-  dgr->value_map = NULL;
+  free(dgr->value_table.bulk_map);
+  dgr->value_table.bulk_map_size = 0;
+  dgr->value_table.bulk_map = NULL;
 
   if (dgr->fd >= 0) {
     munmap(dgr->buffer, dgr->sb.st_size);
@@ -180,7 +188,7 @@ void unload_dual_graph_reader(dual_graph_reader *dgr) {
 
     dgr->keyspace._.compressor.checkpoints = NULL;
     dgr->keyspace._.compressor.deltas = NULL;
-    dgr->value_ids = NULL;
+    dgr->value_table.bulk_ids = NULL;
   }
 }
 
@@ -253,12 +261,17 @@ dual_value get_dual_graph_reader_value_(const dual_graph_reader *dgr, const stat
     key = dgr->to_key(dgr, s);
   }
 
-  dual_value v = dgr->value_map[dgr->value_ids[key]];
-  v.plain.low += delta;
-  v.plain.high += delta;
-  v.forcing.low += delta;
-  v.forcing.high += delta;
-  return v;
+  dual_table_value tv = get_frozen_hash_value(&(dgr->value_table), key);
+  return (dual_value){
+    {
+      score_q7_to_float(tv.plain.low) + delta,
+      score_q7_to_float(tv.plain.high) + delta,
+    },
+    {
+      score_q7_to_float(tv.forcing.low) + delta,
+      score_q7_to_float(tv.forcing.high) + delta,
+    },
+  };
 }
 
 dual_value get_dual_graph_reader_value(const dual_graph_reader *dgr, const state *s) {
@@ -493,17 +506,24 @@ int compare_dual_table_values(const void *a_, const void *b_) {
   return 0;
 }
 
-dual_table_value* create_value_map(dual_graph *dg, size_t *value_map_size) {
+typedef struct tree_value {
+  dual_table_value value;
+  size_t count;
+} tree_value;
+
+frozen_hash_table prepare_frozen_hash(const dual_graph *dg, size_t *num_unique) {
   void *root = NULL;
   dual_table_value *v;
   dual_table_value **tv;
-  size_t num_unique = 0;
+  *num_unique = 0;
 
   for (size_t i = 0; i < dg->keyspace._.size; ++i) {
-    v = malloc(sizeof(dual_table_value));
+    // Allocate value and count
+    v = malloc(sizeof(tree_value));
     if (!v) {
       exit(EXIT_FAILURE);
     }
+    // Abuse struct overlap
     v->plain.low = dg->plain_values[i].low;
     v->plain.high = dg->plain_values[i].high;
     v->forcing.low = dg->forcing_values[i].low;
@@ -513,22 +533,97 @@ dual_table_value* create_value_map(dual_graph *dg, size_t *value_map_size) {
       exit(EXIT_FAILURE);
     }
     if (*tv == v) {
-      num_unique++;
+      (*num_unique)++;
+      ((tree_value *) v)->count = 1;
     } else {
       free(v);
+
+      v = *tv;
+      ((tree_value *) v)->count++;
     }
   }
 
-  dual_table_value *result = malloc(num_unique * sizeof(dual_table_value));
+  dual_table_value *value_map = malloc((*num_unique) * sizeof(dual_table_value));
 
-  *value_map_size = 0;
+  size_t i = 0;
   void action(const void *nodep, VISIT which, int) {
     if (which == postorder || which == leaf) {
-      result[(*value_map_size)++] = **(dual_table_value**) nodep;
+      value_map[i++] = (*(tree_value **) nodep)->value;
     }
   }
   twalk(root, action);
+
+  if ((*num_unique) <= VALUE_MAP_SIZE - 1) {
+    tdestroy(root, free);
+
+    return (frozen_hash_table) {*num_unique, value_map, NULL, 0, NULL, NULL};
+  }
+
+  int cmp(const void *a_, const void *b_) {
+    tree_value *a = *(tree_value **)tfind(a_, &root, compare_dual_table_values);
+    tree_value *b = *(tree_value **)tfind(b_, &root, compare_dual_table_values);
+
+    // Sort most common to front
+    if (a->count > b->count) {
+      return -1;
+    }
+    if (a->count < b->count) {
+      return 1;
+    }
+    return 0;
+  }
+  qsort(value_map, *num_unique, sizeof(dual_table_value), cmp);
+
+  const size_t n = VALUE_MAP_SIZE - 1;
+
+  size_t tail_size = 0;
+  for (size_t i = n; i < *num_unique; ++i) {
+    tail_size += (*(tree_value **)tfind(value_map + i, &root, compare_dual_table_values))->count;
+  }
+
   tdestroy(root, free);
 
-  return result;
+  value_map = realloc(value_map, n * sizeof(dual_table_value));
+  if (!value_map) {
+    exit(EXIT_FAILURE);
+  }
+  qsort(value_map, n, sizeof(dual_table_value), compare_dual_table_values);
+
+  size_t *tail_keys = malloc(tail_size * sizeof(size_t));
+  if (!tail_keys) {
+    exit(EXIT_FAILURE);
+  }
+  dual_table_value *tail_values = malloc(tail_size * sizeof(dual_table_value));
+  if (!tail_values) {
+    exit(EXIT_FAILURE);
+  }
+
+  v = malloc(sizeof(dual_table_value));
+  if (!v) {
+    exit(EXIT_FAILURE);
+  }
+  size_t j = 0;
+  for (size_t i = 0; i < dg->keyspace._.size; ++i) {
+    v->plain.low = dg->plain_values[i].low;
+    v->plain.high = dg->plain_values[i].high;
+    v->forcing.low = dg->forcing_values[i].low;
+    v->forcing.high = dg->forcing_values[i].high;
+    if (!bsearch(v, value_map, n, sizeof(dual_table_value), compare_dual_table_values)) {
+      tail_keys[j] = i;
+      tail_values[j++] = *v;
+    }
+  }
+  assert(j == tail_size);
+  free(v);
+
+  return (frozen_hash_table) {n, value_map, NULL, tail_size, tail_values, tail_keys};
+}
+
+dual_table_value get_frozen_hash_value(const frozen_hash_table *fht, size_t key) {
+  value_id_t vid = fht->bulk_ids[key];
+  if (vid == VALUE_ID_SENTINEL) {
+    size_t i = ((size_t*)bsearch(&key, fht->tail_keys, fht->tail_size, sizeof(size_t), compare_keys)) - fht->tail_keys;
+    return fht->tail_values[i];
+  }
+  return fht->bulk_map[vid];
 }

--- a/src/dual_solver.c
+++ b/src/dual_solver.c
@@ -110,13 +110,16 @@ dual_graph create_dual_graph(const state *root, keyspace_type type) {
     dg.was_legal = _was_compressed_legal;
     dg.remap_key = _remap_tight_key;
     dg.from_fast_key = _from_tight_key;
-  } else {
+  } else if (type == SYMMETRIC_KEYSPACE) {
     dg.keyspace.symmetric = create_symmetric_keyspace(root);
     dg.to_key = _to_symmetric_key;
     dg.from_key = _from_symmetric_key;
     dg.was_legal = _was_symmetric_legal;
     dg.remap_key = _remap_fast_key;
     dg.from_fast_key = _from_fast_key;
+  } else {
+    fprintf(stderr, "Mock keyspaces cannot be directly constructed\n");
+    exit(EXIT_FAILURE);
   }
 
   int num_player_chains = 0;
@@ -152,9 +155,9 @@ dual_graph create_dual_graph(const state *root, keyspace_type type) {
   return dg;
 }
 
-dual_graph* allocate_dual_graph(const state *root) {
+dual_graph* allocate_dual_graph(const state *root, keyspace_type type) {
   dual_graph *result = malloc(sizeof(dual_graph));
-  *result = create_dual_graph(root, COMPRESSED_KEYSPACE);
+  *result = create_dual_graph(root, type);
   return result;
 }
 
@@ -584,8 +587,11 @@ state dual_graph_high_terminal(dual_graph *dg, const state *origin, tactics ts) 
 void free_dual_graph(dual_graph *dg) {
   if (dg->type == COMPRESSED_KEYSPACE) {
     free_compressed_keyspace(&(dg->keyspace.compressed));
-  } else {
+  } else if (dg->type == SYMMETRIC_KEYSPACE) {
     free_symmetric_keyspace(&(dg->keyspace.symmetric));
+  } else {
+    fprintf(stderr, "Mock keyspaces cannot be directly freed\n");
+    exit(EXIT_FAILURE);
   }
 
   free(dg->moves);

--- a/test/test_dual_reader.c
+++ b/test/test_dual_reader.c
@@ -38,15 +38,15 @@ void test_bulky_five() {
   while(area_iterate_dual_graph(&dg, true));
 
   size_t value_map_size = 0;
-  dual_table_value *value_map = create_value_map(&dg, &value_map_size);
+  frozen_hash_table fht = prepare_frozen_hash(&dg, &value_map_size);
   printf("%zu unique value quads in the graph\n", value_map_size);
   assert(value_map_size == 16);
 
   char *buffer = malloc(MEM_FILE_SIZE);
   FILE *stream = fmemopen(buffer, MEM_FILE_SIZE, "wb");
-  write_dual_graph(&dg, value_map, value_map_size, stream);
+  write_dual_graph(&dg, &fht, stream);
   fclose(stream);
-  free(value_map);
+  free(fht.bulk_map);
   free_dual_graph(&dg);
 
   dual_graph_reader dgr = {0};
@@ -54,8 +54,12 @@ void test_bulky_five() {
   dgr.buffer = buffer;
   unbuffer_dual_graph_reader(&dgr);
 
-  for (size_t i = 0; i < dgr.value_map_size; ++i) {
-    dual_value v = dgr.value_map[i];
+  for (size_t i = 0; i < dgr.value_table.bulk_map_size; ++i) {
+    dual_table_value tv = dgr.value_table.bulk_map[i];
+    dual_value v = (dual_value) {
+      {score_q7_to_float(tv.plain.low), score_q7_to_float(tv.plain.high)},
+      {score_q7_to_float(tv.forcing.low), score_q7_to_float(tv.forcing.high)},
+    };
     printf("#%zu: (%f, %f), (%f, %f)\n", i, v.plain.low, v.plain.high, v.forcing.low, v.forcing.high);
   }
 
@@ -99,15 +103,15 @@ void test_external_liberties() {
   while(area_iterate_dual_graph(&dg, true));
 
   size_t value_map_size = 0;
-  dual_table_value *value_map = create_value_map(&dg, &value_map_size);
+  frozen_hash_table fht = prepare_frozen_hash(&dg, &value_map_size);
   printf("%zu unique value quads in the graph\n", value_map_size);
   assert(value_map_size == 31);
 
   char *buffer = malloc(MEM_FILE_SIZE);
   FILE *stream = fmemopen(buffer, MEM_FILE_SIZE, "wb");
-  write_dual_graph(&dg, value_map, value_map_size, stream);
+  write_dual_graph(&dg, &fht, stream);
   fclose(stream);
-  free(value_map);
+  free(fht.bulk_map);
   free_dual_graph(&dg);
 
   dual_graph_reader dgr = {0};
@@ -115,8 +119,12 @@ void test_external_liberties() {
   dgr.buffer = buffer;
   unbuffer_dual_graph_reader(&dgr);
 
-  for (size_t i = 0; i < dgr.value_map_size; ++i) {
-    dual_value v = dgr.value_map[i];
+  for (size_t i = 0; i < dgr.value_table.bulk_map_size; ++i) {
+    dual_table_value tv = dgr.value_table.bulk_map[i];
+    dual_value v = (dual_value) {
+      {score_q7_to_float(tv.plain.low), score_q7_to_float(tv.plain.high)},
+      {score_q7_to_float(tv.forcing.low), score_q7_to_float(tv.forcing.high)},
+    };
     printf("#%zu: (%f, %f), (%f, %f)\n", i, v.plain.low, v.plain.high, v.forcing.low, v.forcing.high);
   }
 
@@ -206,8 +214,126 @@ void test_external_liberties() {
   free(buffer);
 }
 
+void test_frozen_hash_table() {
+  // There's no natural way to construct frozen hash tables so we mock the game graph and disk round-trip
+  dual_graph dg = {0};
+  dg.type = MOCK_KEYSPACE;
+
+  const size_t num_common = 20000;
+  const size_t num_uncommon = 40000;
+  const size_t num_rare = 20000;
+
+  assert(num_common + num_uncommon + num_rare > VALUE_MAP_SIZE);
+
+  dg.keyspace._.size = 3 * num_common + 2 * num_uncommon + num_rare;
+
+  dg.plain_values = malloc(dg.keyspace._.size * sizeof(table_value));
+  dg.forcing_values = malloc(dg.keyspace._.size * sizeof(table_value));
+
+  for (size_t i = 0; i < num_rare; ++i) {
+    dg.plain_values[i].low = (score_q7_t) (i + 1);
+    dg.plain_values[i].high = 0;
+    dg.forcing_values[i].low = 0;
+    dg.forcing_values[i].high = 0;
+  }
+
+  for (size_t i = 0; i < num_uncommon; ++i) {
+    size_t i0 = num_rare + i;
+    size_t i1 = num_rare + num_uncommon + i;
+    dg.plain_values[i0].low = dg.plain_values[i1].low = 0;
+    dg.plain_values[i0].high = dg.plain_values[i1].high = (score_q7_t) (i + 1);  // Intentional overflow to negative
+    dg.forcing_values[i0].low = dg.forcing_values[i1].low = 0;
+    dg.forcing_values[i0].high = dg.forcing_values[i1].high = 0;
+  }
+
+  for (size_t i = 0; i < num_common; ++i) {
+    size_t j = num_rare + 2 * num_uncommon + 3*i;
+    dg.plain_values[j + 0].low = dg.plain_values[j + 1].low = dg.plain_values[j + 2].low = 0;
+    dg.plain_values[j + 0].high = dg.plain_values[j + 1].high = dg.plain_values[j + 2].high = 0;
+    dg.forcing_values[j + 0].low = dg.forcing_values[j + 1].low = dg.forcing_values[j + 2].low = (score_q7_t) (i + 1);
+    dg.forcing_values[j + 0].high = dg.forcing_values[j + 1].high = dg.forcing_values[j + 2].high = 0;
+  }
+
+  size_t num_unique = 0;
+  frozen_hash_table fht = prepare_frozen_hash(&dg, &num_unique);
+
+  assert(num_unique == num_common + num_uncommon + num_rare);
+
+  assert(fht.tail_size == num_unique - (VALUE_MAP_SIZE - 1));
+
+  // Mock bulk map
+  fht.bulk_ids = malloc(dg.keyspace._.size * sizeof(value_id_t));
+  for (size_t i = 0; i < dg.keyspace._.size; ++i) {
+    dual_table_value v = (dual_table_value) {
+      dg.plain_values[i],
+      dg.forcing_values[i],
+    };
+    dual_table_value *tv = bsearch(&v, fht.bulk_map, fht.bulk_map_size, sizeof(dual_table_value), compare_dual_table_values);
+    fht.bulk_ids[i] = tv ? (value_id_t) (tv - fht.bulk_map) : VALUE_ID_SENTINEL;
+  }
+
+  // Make sure it works
+  for (size_t i = 0; i < dg.keyspace._.size; ++i) {
+    dual_table_value v = get_frozen_hash_value(&fht, i);
+    assert(v.plain.low == dg.plain_values[i].low);
+    assert(v.plain.high == dg.plain_values[i].high);
+    assert(v.forcing.low == dg.forcing_values[i].low);
+    assert(v.forcing.high == dg.forcing_values[i].high);
+  }
+
+  // Clear specific mocks
+  free(fht.bulk_ids);
+  fht.bulk_ids = NULL;
+
+  const size_t mem_file_size = (
+    MEM_FILE_SIZE +
+    dg.keyspace._.size * sizeof(value_id_t) +
+    fht.bulk_map_size * sizeof(dual_table_value) +
+    fht.tail_size * (sizeof(size_t) + sizeof(dual_table_value))
+  );
+
+  char *buffer = malloc(mem_file_size);
+  for (size_t i = 0; i < mem_file_size; ++i) {
+    buffer[i] = 1;
+  }
+  FILE *stream = fmemopen(buffer, mem_file_size, "wb");
+  write_dual_graph(&dg, &fht, stream);
+  fclose(stream);
+
+  dual_graph_reader dgr = {0};
+  dgr.fd = -1;
+  dgr.buffer = buffer;
+  unbuffer_dual_graph_reader(&dgr);
+
+  assert(dgr.value_table.bulk_map_size == fht.bulk_map_size);
+  assert(dgr.value_table.tail_size == fht.tail_size);
+
+  // Free generic mocks
+  free(fht.bulk_map);
+  free(fht.tail_keys);
+  free(fht.tail_values);
+
+  // Make sure it works after the mock round-trip
+  for (size_t i = 0; i < dg.keyspace._.size; ++i) {
+    dual_table_value v = get_frozen_hash_value(&(dgr.value_table), i);
+    assert(v.plain.low == dg.plain_values[i].low);
+    assert(v.plain.high == dg.plain_values[i].high);
+    assert(v.forcing.low == dg.forcing_values[i].low);
+    assert(v.forcing.high == dg.forcing_values[i].high);
+  }
+
+  // Free generic mocks
+  free(dg.plain_values);
+  free(dg.forcing_values);
+  unload_dual_graph_reader(&dgr);
+
+  // Free memory file
+  free(buffer);
+}
+
 int main() {
   test_bulky_five();
   test_external_liberties();
+  test_frozen_hash_table();
   return 0;
 }


### PR DESCRIPTION
Use a bsearch indexer for the potential overflow tail.

ref #68